### PR TITLE
Update to handle halos

### DIFF
--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
@@ -40,16 +40,16 @@ LocalOrcaGrid::LocalOrcaGrid(const OrcaGrid& grid, const SurroundingRectangle& r
 
   // Ensure we include the orca halo points if we are at the edge of the orca grid.
   if (rectangle.ix_min() <= 0) {
-    ix_orca_min_ = -orca_.haloWest();
+    ix_orca_min_ = std::min(rectangle.ix_min(), -orca_.haloWest());
   }
   if (rectangle.ix_max() >= orca_.nx() - 1) {
-    ix_orca_max_ = orca_.nx() + orca_.haloEast() - 1;
+    ix_orca_max_ = std::max(rectangle.ix_max(), orca_.nx() + orca_.haloEast() - 1);
   }
   if (rectangle.iy_min() <= 0) {
-    iy_orca_min_ = -orca_.haloSouth();
+    iy_orca_min_ = std::min(rectangle.iy_min(), -orca_.haloSouth());
   }
   if (rectangle.iy_max() >= orca_.ny() - 1) {
-    iy_orca_max_ = orca_.ny() + orca_.haloNorth() - 1;
+    iy_orca_max_ = std::max(rectangle.iy_max(), orca_.ny() + orca_.haloNorth() - 1);
   }
 
 //  std::cout << " orca_.nx() " << orca_.nx()
@@ -83,6 +83,7 @@ LocalOrcaGrid::LocalOrcaGrid(const OrcaGrid& grid, const SurroundingRectangle& r
         const auto ij_glb_haloed = this->global_ij( ix, iy );
         idx_t ix_reg = ij_glb_haloed.i;
         idx_t iy_reg = ij_glb_haloed.j;
+        
         if (ix_reg < rectangle.ix_min()) {
           ix_reg = rectangle.ix_min();
         } else if (ix_reg > rectangle.ix_max()) {

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
@@ -46,6 +46,11 @@ LocalOrcaGrid::LocalOrcaGrid(const OrcaGrid& grid, const SurroundingRectangle& r
     iy_orca_max_ = std::max(rectangle.iy_max(), orca_.ny() + orca_.haloNorth() - 1);
   }
 
+  // TEMPORARY: Prevent wrapping at edge of grid.
+  ix_orca_min_ = std::max(ix_orca_min_, -orca_.haloWest());
+  ix_orca_max_ = std::min(ix_orca_max_, orca_.nx() + orca_.haloEast() - 1);
+  iy_orca_max_ = std::min(iy_orca_max_, orca_.ny() + orca_.haloNorth() - 1);
+
   // Dimensions of the rectangle including the ORCA halo points
   // NOTE: +1 because the size of the dimension is one bigger than index of the last element
   nx_orca_ = ix_orca_max_ - ix_orca_min_ + 1;

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
@@ -46,11 +46,6 @@ LocalOrcaGrid::LocalOrcaGrid(const OrcaGrid& grid, const SurroundingRectangle& r
     iy_orca_max_ = std::max(rectangle.iy_max(), orca_.ny() + orca_.haloNorth() - 1);
   }
 
-  // TEMPORARY: Prevent wrapping at edge of grid.
-  ix_orca_min_ = std::max(ix_orca_min_, -orca_.haloWest());
-  ix_orca_max_ = std::min(ix_orca_max_, orca_.nx() + orca_.haloEast() - 1);
-  iy_orca_max_ = std::min(iy_orca_max_, orca_.ny() + orca_.haloNorth() - 1);
-
   // Dimensions of the rectangle including the ORCA halo points
   // NOTE: +1 because the size of the dimension is one bigger than index of the last element
   nx_orca_ = ix_orca_max_ - ix_orca_min_ + 1;
@@ -139,11 +134,13 @@ LocalOrcaGrid::LocalOrcaGrid(const OrcaGrid& grid, const SurroundingRectangle& r
     nb_used_nodes_ = 0;
     for ( idx_t iy = 0; iy < ny_orca_-1; iy++ ) {
       for ( idx_t ix = 0; ix < nx_orca_-1; ix++ ) {
-        mark_cell_used( ix, iy );
-        mark_node_used( ix, iy );
-        mark_node_used( ix + 1, iy );
-        mark_node_used( ix + 1, iy + 1 );
-        mark_node_used( ix, iy + 1 );
+        if ( ! is_ghost[index( ix, iy )]) {
+          mark_cell_used( ix, iy );
+          mark_node_used( ix, iy );
+          mark_node_used( ix + 1, iy );
+          mark_node_used( ix + 1, iy + 1 );
+          mark_node_used( ix, iy + 1 );
+        }
       }
     }
   }

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
@@ -65,6 +65,8 @@ LocalOrcaGrid::LocalOrcaGrid(const OrcaGrid& grid, const SurroundingRectangle& r
   is_ghost.resize( size_, 1 );
   nb_used_real_nodes_ = 0;
   nb_used_ghost_nodes_ = 0;
+  nb_used_real_cells_ = 0;
+  nb_used_ghost_cells_ = 0;
   uint16_t nb_used_halo_nodes = 0;
   {
     //atlas_omp_parallel_for( idx_t iy = 0; iy < ny_; iy++ )
@@ -132,6 +134,11 @@ LocalOrcaGrid::LocalOrcaGrid(const OrcaGrid& grid, const SurroundingRectangle& r
       if ( !is_cell.at(ii) ) {
         ++nb_cells_;
         is_cell.at(ii) = true;
+        if ( is_ghost.at( ii ) ) {
+          ++nb_used_ghost_cells_;
+        } else {
+          ++nb_used_real_cells_;
+        }
       }
     };
     // Loop over all elements to determine which are required

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
@@ -46,11 +46,6 @@ LocalOrcaGrid::LocalOrcaGrid(const OrcaGrid& grid, const SurroundingRectangle& r
     iy_orca_max_ = std::max(rectangle.iy_max(), orca_.ny() + orca_.haloNorth() - 1);
   }
 
-  // TEMPORARY: Prevent wrapping at edge of grid.
-  ix_orca_min_ = std::max(ix_orca_min_, -orca_.haloWest());
-  ix_orca_max_ = std::min(ix_orca_max_, orca_.nx() + orca_.haloEast() - 1);
-  iy_orca_max_ = std::min(iy_orca_max_, orca_.ny() + orca_.haloNorth() - 1);
-
   // Dimensions of the rectangle including the ORCA halo points
   // NOTE: +1 because the size of the dimension is one bigger than index of the last element
   nx_orca_ = ix_orca_max_ - ix_orca_min_ + 1;

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.h
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.h
@@ -55,6 +55,10 @@ class LocalOrcaGrid {
     uint64_t nb_used_nodes() const {return nb_used_nodes_;}
     // number of cells on this partition
     uint64_t nb_cells() const {return nb_cells_;}
+    // number of ghost cells on this partition
+    uint64_t nb_used_ghost_cells() const {return nb_used_ghost_cells_;}
+    // number of real cells on this paritition
+    uint64_t nb_used_real_cells() const {return nb_used_real_cells_;}
 
     int index( idx_t ix, idx_t iy ) const;
     LocalOrcaGrid( const OrcaGrid& grid, const SurroundingRectangle& rectangle );
@@ -83,6 +87,8 @@ class LocalOrcaGrid {
     uint64_t nb_used_real_nodes_;
     uint64_t nb_used_ghost_nodes_;
     uint64_t nb_cells_;
+    uint64_t nb_used_ghost_cells_;
+    uint64_t nb_used_real_cells_;
     double lon00_;
     util::NormaliseLongitude lon00_normaliser_;
 };

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.h
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.h
@@ -39,6 +39,7 @@ class LocalOrcaGrid {
     std::vector<int> is_ghost_including_orca_halo;
     std::vector<int> is_ghost;
     std::vector<int> is_node;
+    std::vector<int> is_cell;
     uint64_t size() const {return size_;}
     int ix_min() const {return ix_orca_min_;}
     int ix_max() const {return ix_orca_max_;}

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.h
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.h
@@ -67,6 +67,7 @@ class LocalOrcaGrid {
     idx_t orca_haloed_global_grid_index( idx_t ix, idx_t iy ) const;
     void flags( idx_t ix, idx_t iy, util::detail::BitflagsView<int>& flag_view ) const;
     bool water( idx_t ix, idx_t iy ) const;
+    bool orca_halo( idx_t ix, idx_t iy ) const;
 
  private:
     const OrcaGrid orca_;

--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
@@ -219,70 +219,10 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
     int inode_nonghost = 0;
     int inode_ghost    = 0;
 
-
     int ix_pivot = SR_cfg.nx_glb / 2;
     bool patch   = not orca_grid.ghost( ix_pivot + 1, SR_cfg.ny_glb - 1 );
 
     std::vector<idx_t> node_index( local_orca.nx()*local_orca.ny(), -1 );
-
-//    std::stringstream file_spec;
-//    file_spec << orca_grid.name() << "_" << distribution.type() << nparts_ << "_" << mypart_;
-
-//    std::ofstream summary_file, partition_file, ghost_file, is_node_file, xy_file, lonlat_file, cells_file, orca_halo_file;
-//    summary_file.open(file_spec.str() + "_summary.txt");
-//    partition_file.open(file_spec.str() + "_partition.txt");
-//    ghost_file.open(file_spec.str() + "_ghost.txt");
-//    is_node_file.open(file_spec.str() + "_is_node.txt");
-//    xy_file.open(file_spec.str() + "_xy.txt");
-//    lonlat_file.open(file_spec.str() + "_lonlat.txt");
-//    cells_file.open(file_spec.str() + "_cells.txt");
-//    orca_halo_file.open(file_spec.str() + "_orca_halo.txt");
-
-//    orca_halo_file << "inode , ii, nodes.ij( inode, XX ), nodes.ij( inode, YY )"
-//                   << ", nodes.part( inode )"
-//                   << ", nodes.ghost( inode )"
-//                   << ", nodes.remote_idx( inode )"
-//                   << ", nodes.glb_idx( inode )"
-//                   << ", nodes.master_glb_idx( inode )" << std::endl;
-
-//    summary_file << "SR.nx " << SR.nx()
-//                 << "\nSR.ny " << SR.ny()
-//                 << "\nSR.ix_min " << SR.ix_min()
-//                 << "\nSR.ix_max " << SR.ix_max()
-//                 << "\nSR.iy_min " << SR.iy_min()
-//                 << "\nSR.iy_max " << SR.iy_max()
-//                 << "\nSR.nb_nodes_owned " << SR.nb_real_nodes_owned_by_rectangle
-//                 << "\nlocal_orca.nx " << local_orca.nx()
-//                 << "\nlocal_orca.ny " << local_orca.ny()
-//                 << "\nlocal_orca.ix_min " << local_orca.ix_min()
-//                 << "\nlocal_orca.ix_max " << local_orca.ix_max()
-//                 << "\nlocal_orca.iy_min " << local_orca.iy_min()
-//                 << "\nlocal_orca.iy_max " << local_orca.iy_max()
-//                 << "\nlocal_orca.nb_used_real_nodes " << local_orca.nb_used_real_nodes()
-//                 << "\nlocal_orca.nb_used_ghost_nodes " << local_orca.nb_used_ghost_nodes()
-//                 << "\nlocal_orca.nb_used_nodes " << local_orca.nb_used_nodes()
-//                 << std::endl;
-//    int total_is_node = std::count(local_orca.is_node.begin(), local_orca.is_node.end(), true);
-//    int total_is_ghost = std::count(local_orca.is_ghost.begin(), local_orca.is_ghost.end(), true);
-//    std::cout    << "SR.nx " << SR.nx()
-//                 << "\nSR.ny " << SR.ny()
-//                 << "\nSR.ix_min " << SR.ix_min()
-//                 << "\nSR.ix_max " << SR.ix_max()
-//                 << "\nSR.iy_min " << SR.iy_min()
-//                 << "\nSR.iy_max " << SR.iy_max()
-//                 << "\nSR.nb_nodes_owned " << SR.nb_real_nodes_owned_by_rectangle
-//                 << "\nlocal_orca.nx " << local_orca.nx()
-//                 << "\nlocal_orca.ny " << local_orca.ny()
-//                 << "\nlocal_orca.ix_min " << local_orca.ix_min()
-//                 << "\nlocal_orca.ix_max " << local_orca.ix_max()
-//                 << "\nlocal_orca.iy_min " << local_orca.iy_min()
-//                 << "\nlocal_orca.iy_max " << local_orca.iy_max()
-//                 << "\nlocal_orca.nb_used_real_nodes " << local_orca.nb_used_real_nodes()
-//                 << "\nlocal_orca.nb_used_ghost_nodes " << local_orca.nb_used_ghost_nodes()
-//                 << "\nlocal_orca.nb_used_nodes " << local_orca.nb_used_nodes()
-//                 << "\ntotal is node " << total_is_node
-//                 << "\ntotal is ghost" << total_is_ghost
-//                 << std::endl;
 
     {
         ATLAS_TRACE( "nodes" );
@@ -386,31 +326,7 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
 
                     nodes.water( inode ) = local_orca.water( ix, iy );
                     nodes.halo( inode ) = local_orca.halo[ii];
-                    // print diagnostic properties of nodes
-//                    partition_file << inode << ", " << ii << ", " << nodes.part( inode ) << std::endl;
-//                    ghost_file << inode << ", " << ii << ", " << nodes.ghost( inode ) << std::endl;
-//                    xy_file << inode << ", " << ii << ", " << nodes.xy( inode, 0 ) << ", " << nodes.xy( inode, 1 ) << std::endl;
-//                    lonlat_file << inode << ", " << ii << ", " << nodes.lonlat( inode, 0 ) << ", " << nodes.lonlat( inode, 1 ) << std::endl;
-//                    if ((nodes.ij( inode, XX ) > orca_grid.nx()) ||
-//                        (nodes.ij( inode, XX ) > orca_grid.nx()/2 &&  nodes.ij( inode, YY ) > orca_grid.ny())) {
-//                      orca_halo_file << inode << ", " << ii << ", " << nodes.ij( inode, XX ) << ", " << nodes.ij( inode, YY )
-//                                                            << ", " << nodes.part( inode )
-//                                                            << ", " << nodes.ghost( inode )
-//                                                            << ", " << nodes.remote_idx( inode )
-//                                                            << ", " << nodes.glb_idx( inode )
-//                                                            << ", " << nodes.master_glb_idx( inode ) << std::endl;
-//                    }
-                    // this node doesn't seem to belong on any partition when I build the remote indices
-//                    if ( ( nodes.master_glb_idx( inode ) == 26575 ) ) {
-//                      std::cout << "[" << mypart_ << "] " << inode << ", " << ii << ", " << nodes.ij( inode, XX ) << ", " << nodes.ij( inode, YY )
-//                                                          << ", " << nodes.part( inode )
-//                                                          << ", " << nodes.ghost( inode )
-//                                                          << ", " << nodes.remote_idx( inode )
-//                                                          << ", " << nodes.glb_idx( inode )
-//                                                          << ", " << nodes.master_glb_idx( inode ) << std::endl;
-//                    }
                 }
-//                is_node_file << local_orca.is_node.at( ii ) << std::endl;
             }
         }
     }
@@ -508,10 +424,6 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
                     if ( orca_grid.invalidElement( local_orca.ix_min() + ix, local_orca.iy_min() + iy ) ) {
                         cells.flags( jcell ).set( Topology::INVALID );
                     }
-//                    cells_file << jcell << ", " << quad_nodes[0]
-//                                        << ", " << quad_nodes[1]
-//                                        << ", " << quad_nodes[2]
-//                                        << ", " << quad_nodes[3] << std::endl;
                 }
             }
         }
@@ -528,15 +440,6 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
         ATLAS_DEBUG( "build_remote_index" );
         build_remote_index( mesh );
     }
-
-//    summary_file.close();
-//    partition_file.close();
-//    ghost_file.close();
-//    is_node_file.close();
-//    xy_file.close();
-//    lonlat_file.close();
-//    cells_file.close();
-//    orca_halo_file.close();
 
     // Degenerate points in the ORCA mesh mean that the standard BuildHalo
     // methods for updating halo sizes will not work.
@@ -577,9 +480,6 @@ void OrcaMeshGenerator::build_remote_index(Mesh& mesh) const {
     std::vector<std::vector<gidx_t>> send_uid( mpi_size );
     std::vector<std::vector<int>> req_lidx( mpi_size );
 
-//    std::ofstream global2local_file;
-//    global2local_file.open(std::string("global2local_") + std::to_string(mypart) + ".txt");
-//    global2local_file << "uid, jnode" << std::endl;
     Unique2Node global2local;
     for ( idx_t jnode = 0; jnode < nodes.size(); ++jnode ) {
         gidx_t uid = master_glb_idx( jnode );
@@ -592,22 +492,12 @@ void OrcaMeshGenerator::build_remote_index(Mesh& mesh) const {
         else {
             ridx( jnode ) = jnode;
         }
-//        if ( uid == 1 ) {
-//            std::cout << "[" << mypart << "] " << jnode << ", --, " << ij( jnode, XX ) << ", " << ij( jnode, YY )
-//                                                << ", " << part( jnode )
-//                                                << ", " << ghost( jnode )
-//                                                << ", " << ridx( jnode )
-//                                                << ", " << glb_idx( jnode )
-//                                                << ", " << master_glb_idx( jnode ) << std::endl;
-//        }
         if ( ghost( jnode ) == 0 ) {
             bool inserted = global2local.insert( std::make_pair( uid, jnode ) ).second;
             ATLAS_ASSERT( inserted, std::string( "index already inserted " ) + std::to_string( uid ) + ", " +
                                         std::to_string( jnode ) + " at jnode " + std::to_string( global2local[uid] ) );
-//            global2local_file << uid << ", " << jnode << std::endl;
         }
     }
-//    global2local_file.close();
 
     std::vector<std::vector<gidx_t>> recv_uid( mpi_size );
 

--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
@@ -334,10 +334,11 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
         }
     }
     std::vector<idx_t> cell_index( local_orca.nx()*local_orca.ny() );
-    // loop over nodes and define cells
+    // loop over nodes and define cells, putting non-ghost cells first
     {
         ATLAS_TRACE( "elements" );
         idx_t jcell = 0;
+        idx_t jcell_ghost = local_orca.nb_used_real_cells();
         ATLAS_TRACE_SCOPE( "indexing" );
         for ( idx_t iy = 0; iy < local_orca.ny() - 1; iy++ ) {      // don't loop into ghost/periodicity row
             for ( idx_t ix = 0; ix < local_orca.nx() - 1; ix++ ) {  // don't loop into ghost/periodicity column
@@ -345,7 +346,9 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
                 std::stringstream assert_msg;
                 assert_msg << ii << " > " << cell_index.size() << std::endl;
                 ATLAS_ASSERT(ii <  cell_index.size(), assert_msg.str());
-                if ( local_orca.is_ghost[ii] == 0 ) {
+                if ( local_orca.is_ghost[ii] ) {
+                    cell_index[ii] = jcell_ghost++;
+                } else {
                     cell_index[ii] = jcell++;
                 }
             }

--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
@@ -274,7 +274,7 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
 
                     // grid ij coordinates
                     {
-                      const auto ij_glb = local_orca.global_ij( ix, iy );
+                      const auto ij_glb = local_orca.orca_haloed_global_grid_ij( ix, iy );
                       nodes.ij( inode, XX ) = ij_glb.i;
                       nodes.ij( inode, YY ) = ij_glb.j;
                     }

--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
@@ -180,7 +180,7 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
 
     //---------------------------------------------------
 
-    if ( serial_distribution ) {
+    if ( serial_distribution && (halosize_ == 0) ) {
         ATLAS_ASSERT_MSG(ix_glb_max == local_orca.ix_max(),
           std::string("Size of the surrounding rectangle x-space doesn't match up with orca-grid x-space: ")
           + std::to_string(ix_glb_max) + " != " + std::to_string(local_orca.ix_max()) );

--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
@@ -554,8 +554,8 @@ OrcaMeshGenerator::OrcaMeshGenerator( const eckit::Parametrisation& config ) {
     config.get( "partition", mypart_ = mpi::rank() );
     config.get( "partitions", nparts_ = mpi::size() );
     config.get( "halo", halosize_);
-    if (halosize_ < 0 || halosize_ > 1)
-      throw_NotImplemented("Only halo sizes 0 or 1 ORCA grids are currently supported", Here());
+    if (halosize_ < 0)
+      throw_NotImplemented("Halo size must be >= 0", Here());
 }
 
 void OrcaMeshGenerator::generate( const Grid& grid, const grid::Partitioner& partitioner, Mesh& mesh ) const {

--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
@@ -358,7 +358,7 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
                 idx_t ii   = local_orca.index( ix, iy );
                 int ix_glb = local_orca.ix_min() + ix;
                 int iy_glb = local_orca.iy_min() + iy;
-                if ( !local_orca.is_ghost[ii] ) {
+                if ( local_orca.is_cell[ii] ) {
                     idx_t jcell = cell_index[ii];
 
                     // define cell corners (local indices)

--- a/src/atlas-orca/meshgenerator/SurroundingRectangle.cc
+++ b/src/atlas-orca/meshgenerator/SurroundingRectangle.cc
@@ -56,11 +56,11 @@ PointIJ SurroundingRectangle::global_periodic_ij(idx_t ix_glb, idx_t iy_glb) con
 
   // j index north/south boundaries
   if (iy_glb_p > iy_glb_max) {
-    ix_glb_p = width_x - ix_glb_p;
+    ix_glb_p = ix_glb_p + width_x/2;
     iy_glb_p = 2*iy_glb_max - iy_glb_p;
   }
   if (iy_glb_p < 0) {
-    ix_glb_p = width_x - ix_glb_p;
+    ix_glb_p = ix_glb_p + width_x/2;
     iy_glb_p = -iy_glb_p;
   }
 
@@ -164,10 +164,10 @@ SurroundingRectangle::SurroundingRectangle(
   nx_ = ix_max_ - ix_min_ + 1;
   ny_ = iy_max_ - iy_min_ + 1;
 
-//  logFile << "[" << cfg_.mypart << "] ix_min: "     << ix_min_ << std::endl;
-//  logFile << "[" << cfg_.mypart << "] ix_max: "     << ix_max_ << std::endl;
-//  logFile << "[" << cfg_.mypart << "] iy_min: "     << iy_min_ << std::endl;
-//  logFile << "[" << cfg_.mypart << "] iy_max: "     << iy_max_ << std::endl;
+  //std::cout << "[" << cfg_.mypart << "] ix_min: "     << ix_min_ << std::endl;
+  //std::cout << "[" << cfg_.mypart << "] ix_max: "     << ix_max_ << std::endl;
+  //std::cout << "[" << cfg_.mypart << "] iy_min: "     << iy_min_ << std::endl;
+  //std::cout << "[" << cfg_.mypart << "] iy_max: "     << iy_max_ << std::endl;
 
   // upper estimate for number of nodes
   uint64_t size = ny_ * nx_;

--- a/src/atlas-orca/meshgenerator/SurroundingRectangle.cc
+++ b/src/atlas-orca/meshgenerator/SurroundingRectangle.cc
@@ -64,7 +64,7 @@ PointIJ SurroundingRectangle::global_periodic_ij(idx_t ix_glb, idx_t iy_glb) con
     iy_glb_p = -iy_glb_p;
   }
 
-  //// i index periodic east/west boundaries
+  // i index periodic east/west boundaries
   if (ix_glb_p < 0) {
     ix_glb_p = wrap(ix_glb_p + width_x, 0, cfg_.nx_glb);
   }
@@ -105,10 +105,6 @@ SurroundingRectangle::SurroundingRectangle(
   ATLAS_TRACE();
   cfg_.check_consistency();
 
-//  std::ofstream logFile(distribution.type() + "-"
-//      + std::to_string(cfg_.halosize) + "_p"
-//      + std::to_string(cfg_.mypart) + ".log");
-
   // determine rectangle (ix_min_:ix_max_) x (iy_min_:iy_max_) surrounding the nodes on this processor
   ix_min_         = cfg_.nx_glb;
   ix_max_         = 0;
@@ -116,8 +112,6 @@ SurroundingRectangle::SurroundingRectangle(
   iy_max_         = 0;
   nb_real_nodes_owned_by_rectangle = 0;
 
-  // TODO: These "bounds"  are on the imaginary wrapped rectangle including halo and periodic points.
-  // points out of bounds of the reglatlon grid are either in the orca halo points, or are in the halo
   {
     ATLAS_TRACE( "find rectangle bounds" );
     atlas_omp_parallel {
@@ -164,11 +158,6 @@ SurroundingRectangle::SurroundingRectangle(
   nx_ = ix_max_ - ix_min_ + 1;
   ny_ = iy_max_ - iy_min_ + 1;
 
-  //std::cout << "[" << cfg_.mypart << "] ix_min: "     << ix_min_ << std::endl;
-  //std::cout << "[" << cfg_.mypart << "] ix_max: "     << ix_max_ << std::endl;
-  //std::cout << "[" << cfg_.mypart << "] iy_min: "     << iy_min_ << std::endl;
-  //std::cout << "[" << cfg_.mypart << "] iy_max: "     << iy_max_ << std::endl;
-
   // upper estimate for number of nodes
   uint64_t size = ny_ * nx_;
 
@@ -210,15 +199,6 @@ SurroundingRectangle::SurroundingRectangle(
       }
     }
   }
-//  logFile << std::setw(5) << std::setfill('0');
-//  logFile << "[" << cfg_.mypart << "] nx                      = " << nx_ << std::endl;
-//  logFile << "[" << cfg_.mypart << "] ny                      = " << ny_ << std::endl;
-//  logFile << "[" << cfg_.mypart << "] halosize                = " << cfg_.halosize << std::endl;
-//  logFile << "[" << cfg_.mypart << "] ny * nx_                = " << ny_ * nx_ << std::endl;
-//  logFile << "[" << cfg_.mypart << "] ny * (nx_ + 2*halosize) = " << ny_ * (nx_ + 2*cfg_.halosize) << std::endl;
-//  logFile << "[" << cfg_.mypart << "] nb_real_nodes_owned_by_rectangle = " << nb_real_nodes_owned_by_rectangle << std::endl;
-//  logFile << "[" << cfg_.mypart << "] end of SR output" << std::endl;
-//  logFile.close();
 }
 
 }  // namespace atlas::orca::meshgenerator 

--- a/src/atlas-orca/meshgenerator/SurroundingRectangle.cc
+++ b/src/atlas-orca/meshgenerator/SurroundingRectangle.cc
@@ -174,9 +174,11 @@ SurroundingRectangle::SurroundingRectangle(
       for ( idx_t ix = 0; ix < nx_; ix++ ) {
         idx_t ii = index( ix, iy );
         parts.at( ii ) = partition( ix, iy );
+        PointIJ pij = global_periodic_ij( ix_min_ + ix, iy_min_ + iy );
+        bool periodic_point = ( (pij.i != (ix_min_ + ix) ) || (pij.j != (iy_min_ + iy)) );
         bool halo_found = false;
         int halo_dist = cfg_.halosize;
-        if ((cfg_.halosize > 0) && parts.at( ii ) != cfg_.mypart ) {
+        if ((cfg_.halosize > 0) && ((parts.at( ii ) != cfg_.mypart) || periodic_point) ) {
           // search the surrounding halosize index square for a node on my
           // partition to determine the halo distance
           for (idx_t dhy = -cfg_.halosize; dhy <= cfg_.halosize; ++dhy) {
@@ -195,7 +197,7 @@ SurroundingRectangle::SurroundingRectangle(
             halo.at( ii ) = halo_dist;
           }
         }
-        is_ghost.at( ii ) = ( parts.at( ii ) != cfg_.mypart );
+        is_ghost.at( ii ) = ( (parts.at( ii ) != cfg_.mypart) || periodic_point );
       }
     }
   }

--- a/src/atlas-orca/meshgenerator/SurroundingRectangle.h
+++ b/src/atlas-orca/meshgenerator/SurroundingRectangle.h
@@ -79,6 +79,7 @@ class SurroundingRectangle {
     int iy_min() const { return iy_min_; };
     int ix_max() const { return ix_max_; };
     int iy_max() const { return iy_max_; };
+    int halosize() const { return halosize_; };
     uint64_t nb_real_nodes_owned_by_rectangle;
 
  private:
@@ -88,5 +89,6 @@ class SurroundingRectangle {
     uint64_t nx_, ny_;
     int ix_min_, ix_max_;
     int iy_min_, iy_max_;
+    int halosize_;
 };
 }  // namespace atlas::orca::meshgenerator 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -5,73 +5,73 @@ LIST( APPEND ATLAS_TEST_ENVIRONMENT
 
 include_directories( ${PROJECT_SOURCE_DIR}/src )
 
-ecbuild_add_test( TARGET  atlas_test_orca_plugin
-                  SOURCES test_orca_plugin.cc
-                  LIBS    atlas
-                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT} )
+#ecbuild_add_test( TARGET  atlas_test_orca_plugin
+#                  SOURCES test_orca_plugin.cc
+#                  LIBS    atlas
+#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT} )
 
-ecbuild_add_test( TARGET  atlas_test_orca_grid_specs
-                  SOURCES test_orca_grid_specs.cc
-                  LIBS    atlas
-                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT} )
+#ecbuild_add_test( TARGET  atlas_test_orca_grid_specs
+#                  SOURCES test_orca_grid_specs.cc
+#                  LIBS    atlas
+#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT} )
 
-ecbuild_add_test( TARGET  atlas_test_orca_grid
-                  SOURCES test_orca_grid.cc
-                  LIBS    atlas-orca
-                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-                  CONDITION eckit_HAVE_LZ4 )
+#ecbuild_add_test( TARGET  atlas_test_orca_grid
+#                  SOURCES test_orca_grid.cc
+#                  LIBS    atlas-orca
+#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+#                  CONDITION eckit_HAVE_LZ4 )
 
-ecbuild_add_test( TARGET  atlas_test_orca_mesh
-                  SOURCES test_orca_mesh.cc
-                  LIBS    atlas-orca
-                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-                  CONDITION eckit_HAVE_LZ4 )
+#ecbuild_add_test( TARGET  atlas_test_orca_mesh
+#                  SOURCES test_orca_mesh.cc
+#                  LIBS    atlas-orca
+#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+#                  CONDITION eckit_HAVE_LZ4 )
 
-ecbuild_add_test( TARGET  atlas_test_orca_valid_elements
-                  SOURCES test_orca_valid_elements.cc
-                  LIBS    atlas-orca
-                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-                  CONDITION eckit_HAVE_LZ4 )
+#ecbuild_add_test( TARGET  atlas_test_orca_valid_elements
+#                  SOURCES test_orca_valid_elements.cc
+#                  LIBS    atlas-orca
+#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+#                  CONDITION eckit_HAVE_LZ4 )
 
-ecbuild_add_test( TARGET  atlas_test_orca_polygon_locator
-                  SOURCES test_orca_polygon_locator.cc
-                  LIBS    atlas-orca
-                  MPI     2
-                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-                  CONDITION eckit_HAVE_LZ4 AND eckit_HAVE_MPI)
+#ecbuild_add_test( TARGET  atlas_test_orca_polygon_locator
+#                  SOURCES test_orca_polygon_locator.cc
+#                  LIBS    atlas-orca
+#                  MPI     2
+#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+#                  CONDITION eckit_HAVE_LZ4 AND eckit_HAVE_MPI)
 
-ecbuild_add_test( TARGET  atlas_test_orca_mesh_boundaries_NOMPI
-                  SOURCES test_orca_mesh_boundaries.cc
-                  LIBS    atlas-orca
-                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-                  CONDITION eckit_HAVE_LZ4)
+#ecbuild_add_test( TARGET  atlas_test_orca_mesh_boundaries_NOMPI
+#                  SOURCES test_orca_mesh_boundaries.cc
+#                  LIBS    atlas-orca
+#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+#                  CONDITION eckit_HAVE_LZ4)
 
-ecbuild_add_test( TARGET  atlas_test_orca_mesh_boundaries_MPI2
-                  SOURCES test_orca_mesh_boundaries.cc
-                  LIBS    atlas-orca
-                  MPI     2
-                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-                  CONDITION eckit_HAVE_LZ4  AND eckit_HAVE_MPI)
+#ecbuild_add_test( TARGET  atlas_test_orca_mesh_boundaries_MPI2
+#                  SOURCES test_orca_mesh_boundaries.cc
+#                  LIBS    atlas-orca
+#                  MPI     2
+#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+#                  CONDITION eckit_HAVE_LZ4  AND eckit_HAVE_MPI)
 
-ecbuild_add_test( TARGET  atlas_test_orca_surrounding_rectangle_NOMPI
-                  SOURCES test_orca_surrounding_rectangle.cc
-                  LIBS    atlas-orca
-                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-                  CONDITION eckit_HAVE_LZ4 )
+#ecbuild_add_test( TARGET  atlas_test_orca_surrounding_rectangle_NOMPI
+#                  SOURCES test_orca_surrounding_rectangle.cc
+#                  LIBS    atlas-orca
+#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+#                  CONDITION eckit_HAVE_LZ4 )
 
-ecbuild_add_test( TARGET  atlas_test_orca_surrounding_rectangle_MPI2
-                  SOURCES test_orca_surrounding_rectangle.cc
-                  LIBS    atlas-orca
-                  MPI     2
-                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-                  CONDITION eckit_HAVE_LZ4  AND eckit_HAVE_MPI)
+#ecbuild_add_test( TARGET  atlas_test_orca_surrounding_rectangle_MPI2
+#                  SOURCES test_orca_surrounding_rectangle.cc
+#                  LIBS    atlas-orca
+#                  MPI     2
+#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+#                  CONDITION eckit_HAVE_LZ4  AND eckit_HAVE_MPI)
 
-ecbuild_add_test( TARGET  atlas_test_orca_surrounding_rectangle_MPI4
-                  SOURCES test_orca_surrounding_rectangle.cc
-                  LIBS    atlas-orca
-                  MPI     4
-                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-                  CONDITION eckit_HAVE_LZ4  AND eckit_HAVE_MPI)
+#ecbuild_add_test( TARGET  atlas_test_orca_surrounding_rectangle_MPI4
+#                  SOURCES test_orca_surrounding_rectangle.cc
+#                  LIBS    atlas-orca
+#                  MPI     4
+#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+#                  CONDITION eckit_HAVE_LZ4  AND eckit_HAVE_MPI)
 
 ecbuild_add_test( TARGET  atlas_test_orca_local_grid_NOMPI
                   SOURCES test_orca_local_grid.cc
@@ -79,10 +79,10 @@ ecbuild_add_test( TARGET  atlas_test_orca_local_grid_NOMPI
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
                   CONDITION eckit_HAVE_LZ4)
 
-ecbuild_add_test( TARGET  atlas_test_orca_local_grid_MPI2
-                  SOURCES test_orca_local_grid.cc
-                  LIBS    atlas-orca
-                  MPI     2
-                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-                  CONDITION eckit_HAVE_LZ4  AND eckit_HAVE_MPI)
+#ecbuild_add_test( TARGET  atlas_test_orca_local_grid_MPI2
+#                  SOURCES test_orca_local_grid.cc
+#                  LIBS    atlas-orca
+#                  MPI     2
+#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+#                  CONDITION eckit_HAVE_LZ4  AND eckit_HAVE_MPI)
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -5,73 +5,73 @@ LIST( APPEND ATLAS_TEST_ENVIRONMENT
 
 include_directories( ${PROJECT_SOURCE_DIR}/src )
 
-#ecbuild_add_test( TARGET  atlas_test_orca_plugin
-#                  SOURCES test_orca_plugin.cc
-#                  LIBS    atlas
-#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT} )
+ecbuild_add_test( TARGET  atlas_test_orca_plugin
+                  SOURCES test_orca_plugin.cc
+                  LIBS    atlas
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT} )
 
-#ecbuild_add_test( TARGET  atlas_test_orca_grid_specs
-#                  SOURCES test_orca_grid_specs.cc
-#                  LIBS    atlas
-#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT} )
+ecbuild_add_test( TARGET  atlas_test_orca_grid_specs
+                  SOURCES test_orca_grid_specs.cc
+                  LIBS    atlas
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT} )
 
-#ecbuild_add_test( TARGET  atlas_test_orca_grid
-#                  SOURCES test_orca_grid.cc
-#                  LIBS    atlas-orca
-#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-#                  CONDITION eckit_HAVE_LZ4 )
+ecbuild_add_test( TARGET  atlas_test_orca_grid
+                  SOURCES test_orca_grid.cc
+                  LIBS    atlas-orca
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  CONDITION eckit_HAVE_LZ4 )
 
-#ecbuild_add_test( TARGET  atlas_test_orca_mesh
-#                  SOURCES test_orca_mesh.cc
-#                  LIBS    atlas-orca
-#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-#                  CONDITION eckit_HAVE_LZ4 )
+ecbuild_add_test( TARGET  atlas_test_orca_mesh
+                  SOURCES test_orca_mesh.cc
+                  LIBS    atlas-orca
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  CONDITION eckit_HAVE_LZ4 )
 
-#ecbuild_add_test( TARGET  atlas_test_orca_valid_elements
-#                  SOURCES test_orca_valid_elements.cc
-#                  LIBS    atlas-orca
-#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-#                  CONDITION eckit_HAVE_LZ4 )
+ecbuild_add_test( TARGET  atlas_test_orca_valid_elements
+                  SOURCES test_orca_valid_elements.cc
+                  LIBS    atlas-orca
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  CONDITION eckit_HAVE_LZ4 )
 
-#ecbuild_add_test( TARGET  atlas_test_orca_polygon_locator
-#                  SOURCES test_orca_polygon_locator.cc
-#                  LIBS    atlas-orca
-#                  MPI     2
-#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-#                  CONDITION eckit_HAVE_LZ4 AND eckit_HAVE_MPI)
+ecbuild_add_test( TARGET  atlas_test_orca_polygon_locator
+                  SOURCES test_orca_polygon_locator.cc
+                  LIBS    atlas-orca
+                  MPI     2
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  CONDITION eckit_HAVE_LZ4 AND eckit_HAVE_MPI)
 
-#ecbuild_add_test( TARGET  atlas_test_orca_mesh_boundaries_NOMPI
-#                  SOURCES test_orca_mesh_boundaries.cc
-#                  LIBS    atlas-orca
-#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-#                  CONDITION eckit_HAVE_LZ4)
+ecbuild_add_test( TARGET  atlas_test_orca_mesh_boundaries_NOMPI
+                  SOURCES test_orca_mesh_boundaries.cc
+                  LIBS    atlas-orca
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  CONDITION eckit_HAVE_LZ4)
 
-#ecbuild_add_test( TARGET  atlas_test_orca_mesh_boundaries_MPI2
-#                  SOURCES test_orca_mesh_boundaries.cc
-#                  LIBS    atlas-orca
-#                  MPI     2
-#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-#                  CONDITION eckit_HAVE_LZ4  AND eckit_HAVE_MPI)
+ecbuild_add_test( TARGET  atlas_test_orca_mesh_boundaries_MPI2
+                  SOURCES test_orca_mesh_boundaries.cc
+                  LIBS    atlas-orca
+                  MPI     2
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  CONDITION eckit_HAVE_LZ4  AND eckit_HAVE_MPI)
 
-#ecbuild_add_test( TARGET  atlas_test_orca_surrounding_rectangle_NOMPI
-#                  SOURCES test_orca_surrounding_rectangle.cc
-#                  LIBS    atlas-orca
-#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-#                  CONDITION eckit_HAVE_LZ4 )
+ecbuild_add_test( TARGET  atlas_test_orca_surrounding_rectangle_NOMPI
+                  SOURCES test_orca_surrounding_rectangle.cc
+                  LIBS    atlas-orca
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  CONDITION eckit_HAVE_LZ4 )
 
-#ecbuild_add_test( TARGET  atlas_test_orca_surrounding_rectangle_MPI2
-#                  SOURCES test_orca_surrounding_rectangle.cc
-#                  LIBS    atlas-orca
-#                  MPI     2
-#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-#                  CONDITION eckit_HAVE_LZ4  AND eckit_HAVE_MPI)
+ecbuild_add_test( TARGET  atlas_test_orca_surrounding_rectangle_MPI2
+                  SOURCES test_orca_surrounding_rectangle.cc
+                  LIBS    atlas-orca
+                  MPI     2
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  CONDITION eckit_HAVE_LZ4  AND eckit_HAVE_MPI)
 
-#ecbuild_add_test( TARGET  atlas_test_orca_surrounding_rectangle_MPI4
-#                  SOURCES test_orca_surrounding_rectangle.cc
-#                  LIBS    atlas-orca
-#                  MPI     4
-#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-#                  CONDITION eckit_HAVE_LZ4  AND eckit_HAVE_MPI)
+ecbuild_add_test( TARGET  atlas_test_orca_surrounding_rectangle_MPI4
+                  SOURCES test_orca_surrounding_rectangle.cc
+                  LIBS    atlas-orca
+                  MPI     4
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  CONDITION eckit_HAVE_LZ4  AND eckit_HAVE_MPI)
 
 ecbuild_add_test( TARGET  atlas_test_orca_local_grid_NOMPI
                   SOURCES test_orca_local_grid.cc
@@ -79,10 +79,10 @@ ecbuild_add_test( TARGET  atlas_test_orca_local_grid_NOMPI
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
                   CONDITION eckit_HAVE_LZ4)
 
-#ecbuild_add_test( TARGET  atlas_test_orca_local_grid_MPI2
-#                  SOURCES test_orca_local_grid.cc
-#                  LIBS    atlas-orca
-#                  MPI     2
-#                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-#                  CONDITION eckit_HAVE_LZ4  AND eckit_HAVE_MPI)
+ecbuild_add_test( TARGET  atlas_test_orca_local_grid_MPI2
+                  SOURCES test_orca_local_grid.cc
+                  LIBS    atlas-orca
+                  MPI     2
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  CONDITION eckit_HAVE_LZ4  AND eckit_HAVE_MPI)
 

--- a/src/tests/test_orca_local_grid.cc
+++ b/src/tests/test_orca_local_grid.cc
@@ -105,19 +105,24 @@ CASE("test surrounding local_orca ") {
                      std::to_string(grid.haloEast()) + " " + std::to_string(halo));
           auto ii = local_orca.index(i, j);
           indices.emplace_back(ii);
-          gidx_t master_idx = local_orca.master_global_index( i, j );
-          const auto master_global_ij = local_orca.master_global_ij( i, j );
-          ASSERT_MSG(master_global_ij.i < grid.nx(),
-             std::string("master_global_ij.i ") + std::to_string(master_global_ij.i)
-             + " grid.nx() " + std::to_string(grid.nx()) );
-          ASSERT_MSG(master_global_ij.j < grid.ny(),
-             std::string("master_global_ij.j ") + std::to_string(master_global_ij.j)
-             + " grid.ny() " + std::to_string(grid.ny()) );
-          ASSERT_MSG(master_global_ij.i >= -1,
-             std::string("master_global_ij.i ") + std::to_string(master_global_ij.i) +
-             " i j " + std::to_string(i) + " " + std::to_string(j));
-          ASSERT_MSG(master_global_ij.j >= -1,
-             std::string("master_global_ij.j ") + std::to_string(master_global_ij.j));
+
+          gidx_t ohgg_idx = local_orca.orca_haloed_global_grid_index( i, j );
+          const auto ohgg_ij = local_orca.orca_haloed_global_grid_ij( i, j );
+          ASSERT_MSG(ohgg_ij.i < grid.nx() + grid.haloEast(),
+             std::string("ohgg_ij.i ") + std::to_string(ohgg_ij.i)
+             + std::string(" grid.nx()) ") + std::to_string(grid.nx()) 
+             + std::string(" grid.haloEast() ") + std::to_string(grid.haloEast()) );
+          ASSERT_MSG(ohgg_ij.j < grid.ny() + grid.haloNorth(),
+             std::string("ohgg_ij.j ") + std::to_string(ohgg_ij.j)
+             + std::string(" grid.ny() ") + std::to_string(grid.ny()) 
+             + std::string(" grid.haloNorth() ") + std::to_string(grid.haloNorth()) );
+          ASSERT_MSG(ohgg_ij.i >= -grid.haloWest(),
+             std::string("ohgg_ij.i ") + std::to_string(ohgg_ij.i)
+             + std::string(" grid.haloWest() ") + std::to_string(grid.haloWest()) );
+          ASSERT_MSG(ohgg_ij.j >= -grid.haloSouth(),
+             std::string("ohgg_ij.j ") + std::to_string(ohgg_ij.j)
+             + std::string(" grid.haloSouth() ") + std::to_string(grid.haloSouth()) );
+
           const auto grid_xy        = local_orca.grid_xy( i, j );
           const auto normed_grid_xy = local_orca.normalised_grid_xy( i, j );
 
@@ -133,18 +138,19 @@ CASE("test surrounding local_orca ") {
           local_orca.flags( i, j, flags_view );
 
           // check points in the orca halo behave as expected.
-          if ((ix_glb > grid.nx()) ||
-              (ix_glb > grid.nx()/2 && iy_glb > grid.ny())) {
-            //std::cout << "ix_glb, iy_glb : " << ix_glb << ", " << iy_glb << " is_ghost "  << local_orca.is_ghost.at(ii)
-             //<< "local_orca.master_global_index(i, j) != local_orca.orca_haloed_global_grid_index(i,j)"
-             //<< local_orca.master_global_index(i, j) << " != " << local_orca.orca_haloed_global_grid_index(i,j) << " -- " << grid.ghost( ix_glb, iy_glb ) <<std::endl;
+          if (local_orca.orca_halo( i, j ) &&
+              ((ix_glb >= grid.nx()) || (ix_glb > grid.nx()/2 && iy_glb > grid.ny()))) {
             // this grid point should be a ghost point.
-            if ( iy_glb > 0 or ix_glb < 0 ) {
-              EXPECT(local_orca.is_ghost_including_orca_halo.at(ii) >= grid.ghost( ix_glb, iy_glb ));
+            if ( ohgg_ij.j >= 0 or ohgg_ij.i < 0 or ohgg_ij.i >= grid.nx() ) {
+              EXPECT(local_orca.is_ghost_including_orca_halo.at(ii) 
+                     >= grid.ghost( ohgg_ij.i, ohgg_ij.j ));
             }
-            // this grid point should not be a master grid point.
-            EXPECT(local_orca.master_global_index(i, j)
-                   != local_orca.orca_haloed_global_grid_index(i,j));
+            if ( (ix_glb >= -grid.haloWest()) && (ix_glb < grid.nx() + grid.haloEast()) &&
+                 (iy_glb >= -grid.haloSouth()) && (iy_glb < grid.ny() + grid.haloNorth())) {
+              // this grid point should not be a master grid point.
+              EXPECT(local_orca.master_global_index(i, j)
+                     != local_orca.orca_haloed_global_grid_index(i,j));
+            }
           }
         }
       }
@@ -187,22 +193,23 @@ CASE("test surrounding local_orca ") {
       }
 
       const idx_t cell_width = 1;
+      // Values below are for ORCA2_T grid.
       if (cfg.nparts == 2) {
         if (cfg.mypart == 0) {
           EXPECT(local_orca.iy_min() == -grid.haloSouth());
-          EXPECT(local_orca.iy_max() == grid.ny() + grid.haloNorth() - 1);
-          EXPECT(local_orca.ix_min() == -grid.haloWest());
+          EXPECT(local_orca.iy_max() == grid.ny() + halo);
+          EXPECT(local_orca.ix_min() == -std::max(grid.haloWest(), halo));
           EXPECT(local_orca.ix_max() == 90 + halo);
-          EXPECT(local_orca.nx() == 91 + grid.haloWest() + 2*halo);
-          EXPECT(local_orca.ny() == grid.ny() + grid.haloSouth() + grid.haloNorth() + 2*halo);
+          EXPECT(local_orca.nx() == 91 + halo + std::max(grid.haloWest(), halo));
+          EXPECT(local_orca.ny() == grid.ny() + grid.haloSouth() + halo + 1);
         }
         if (cfg.mypart == 1) {
           EXPECT(local_orca.iy_min() == -grid.haloSouth());
-          EXPECT(local_orca.iy_max() == grid.ny() + grid.haloNorth() -1);
+          EXPECT(local_orca.iy_max() == grid.ny() + halo);
           EXPECT(local_orca.ix_min() == 90 - halo);
-          EXPECT(local_orca.ix_max() == grid.nx() + grid.haloEast() + halo - 1);
-          EXPECT(local_orca.nx() == 90 + grid.haloEast() + 2*halo);
-          EXPECT(local_orca.ny() == grid.ny() + grid.haloSouth() + grid.haloNorth() + 2*halo);
+          EXPECT(local_orca.ix_max() == grid.nx() + halo);
+          EXPECT(local_orca.nx() == grid.nx() + 2 * halo - 89);
+          EXPECT(local_orca.ny() == grid.ny() + grid.haloSouth() + halo + 1);
         }
       }
     }

--- a/src/tests/test_orca_surrounding_rectangle.cc
+++ b/src/tests/test_orca_surrounding_rectangle.cc
@@ -59,7 +59,7 @@ CASE("test surrounding rectangle ") {
     return 1 + util::function::vortex_rollup(lon, lat, 0.0);
   };
 
-  for (int halo = 0; halo < 1; ++halo) {
+  for (int halo = 0; halo <= 2; ++halo) {
     SECTION(gridname + "_" + distributionName + "_halo" + std::to_string(halo)) {
       auto grid = OrcaGrid(gridname);
       auto partitioner_config = Config();
@@ -81,16 +81,18 @@ CASE("test surrounding rectangle ") {
       std::cout << "[" << cfg.mypart << "] " << regular_grid.type() << std::endl;
 
       const idx_t cell_width = 1;
-      if (regular_grid.ny() + 2*halo != grid.ny()) {
-        std::cout << regular_grid.ny() + 2*halo << " != " << grid.ny() << std::endl;
-      }
-      EXPECT(regular_grid.ny() + 2*halo == grid.ny());
-      for (idx_t ix = 0; ix < grid.ny(); ++ix) {
-        if (regular_grid.nx(ix) + 2*halo != grid.nx()) {
-          std::cout << regular_grid.nx(ix) + 2*halo << " != " << grid.nx() << std::endl;
-        }
-        EXPECT(regular_grid.nx(ix) + 2*halo == grid.nx());
-      }
+// Need to clarify these EXPECTs. Halo is not used until rectangle is defined below
+// so I do not know how this would be tested here.
+//      if (regular_grid.ny() + 2*halo != grid.ny()) {
+//        std::cout << regular_grid.ny() + 2*halo << " != " << grid.ny() << std::endl;
+//      }
+//      EXPECT(regular_grid.ny() + 2*halo == grid.ny());
+//      for (idx_t ix = 0; ix < grid.ny(); ++ix) {
+//        if (regular_grid.nx(ix) + 2*halo != grid.nx()) {
+//          std::cout << regular_grid.nx(ix) + 2*halo << " != " << grid.nx() << std::endl;
+//        }
+//        EXPECT(regular_grid.nx(ix) + 2*halo == grid.nx());
+//      }
       std::cout << " last index? " << regular_grid.index(grid.nx()-1, grid.ny()-1) << std::endl;
 
       orca::meshgenerator::SurroundingRectangle rectangle(distribution, cfg);
@@ -197,42 +199,42 @@ CASE("test surrounding rectangle ") {
                 << "(ix_min, ix_max) (" << rectangle.ix_min() << ", " << rectangle.ix_max() << ") " << std::endl;
       if (cfg.nparts == 2) {
         if (cfg.mypart == 0) {
-          EXPECT(rectangle.iy_min() == 0);
-          EXPECT(rectangle.iy_max() == 147);
-          EXPECT(rectangle.ix_min() == 0);
-          EXPECT(rectangle.ix_max() == 90);
+          EXPECT(rectangle.iy_min() == 0 - halo);
+          EXPECT(rectangle.iy_max() == 147 + halo);
+          EXPECT(rectangle.ix_min() == 0 - halo);
+          EXPECT(rectangle.ix_max() == 90 + halo);
         }
         if (cfg.mypart == 1) {
-          EXPECT(rectangle.iy_min() == 0);
-          EXPECT(rectangle.iy_max() == 147);
-          EXPECT(rectangle.ix_min() == 90);
-          EXPECT(rectangle.ix_max() == 180);
+          EXPECT(rectangle.iy_min() == 0 - halo);
+          EXPECT(rectangle.iy_max() == 147 + halo);
+          EXPECT(rectangle.ix_min() == 90 - halo);
+          EXPECT(rectangle.ix_max() == 180 + halo);
         }
       }
       if (cfg.nparts == 4) {
         if (cfg.mypart == 0) {
-          EXPECT(rectangle.iy_min() == 0);
-          EXPECT(rectangle.iy_max() == 74);
-          EXPECT(rectangle.ix_min() == 0);
-          EXPECT(rectangle.ix_max() == 90);
+          EXPECT(rectangle.iy_min() == 0 - halo);
+          EXPECT(rectangle.iy_max() == 74 + halo);
+          EXPECT(rectangle.ix_min() == 0 - halo);
+          EXPECT(rectangle.ix_max() == 90 + halo);
         }
         if (cfg.mypart == 1) {
-          EXPECT(rectangle.iy_min() == 0);
-          EXPECT(rectangle.iy_max() == 74);
-          EXPECT(rectangle.ix_min() == 89);
-          EXPECT(rectangle.ix_max() == 180);
+          EXPECT(rectangle.iy_min() == 0 - halo);
+          EXPECT(rectangle.iy_max() == 74 + halo);
+          EXPECT(rectangle.ix_min() == 89 - halo);
+          EXPECT(rectangle.ix_max() == 180 + halo);
         }
         if (cfg.mypart == 2) {
-          EXPECT(rectangle.iy_min() == 73);
-          EXPECT(rectangle.iy_max() == 147);
-          EXPECT(rectangle.ix_min() == 0);
-          EXPECT(rectangle.ix_max() == 91);
+          EXPECT(rectangle.iy_min() == 73 - halo);
+          EXPECT(rectangle.iy_max() == 147 + halo);
+          EXPECT(rectangle.ix_min() == 0 - halo);
+          EXPECT(rectangle.ix_max() == 91 + halo);
         }
         if (cfg.mypart == 3) {
-          EXPECT(rectangle.iy_min() == 73);
-          EXPECT(rectangle.iy_max() == 147);
-          EXPECT(rectangle.ix_min() == 90);
-          EXPECT(rectangle.ix_max() == 180);
+          EXPECT(rectangle.iy_min() == 73 - halo);
+          EXPECT(rectangle.iy_max() == 147 + halo);
+          EXPECT(rectangle.ix_min() == 90 - halo);
+          EXPECT(rectangle.ix_max() == 180 + halo);
         }
       }
     }

--- a/src/tests/test_orca_surrounding_rectangle.cc
+++ b/src/tests/test_orca_surrounding_rectangle.cc
@@ -81,18 +81,16 @@ CASE("test surrounding rectangle ") {
       std::cout << "[" << cfg.mypart << "] " << regular_grid.type() << std::endl;
 
       const idx_t cell_width = 1;
-// Need to clarify these EXPECTs. Halo is not used until rectangle is defined below
-// so I do not know how this would be tested here.
-//      if (regular_grid.ny() + 2*halo != grid.ny()) {
-//        std::cout << regular_grid.ny() + 2*halo << " != " << grid.ny() << std::endl;
-//      }
-//      EXPECT(regular_grid.ny() + 2*halo == grid.ny());
-//      for (idx_t ix = 0; ix < grid.ny(); ++ix) {
-//        if (regular_grid.nx(ix) + 2*halo != grid.nx()) {
-//          std::cout << regular_grid.nx(ix) + 2*halo << " != " << grid.nx() << std::endl;
-//        }
-//        EXPECT(regular_grid.nx(ix) + 2*halo == grid.nx());
-//      }
+      if (regular_grid.ny() != grid.ny()) {
+        std::cout << regular_grid.ny() << " != " << grid.ny() << std::endl;
+      }
+      EXPECT(regular_grid.ny() == grid.ny());
+      for (idx_t ix = 0; ix < grid.ny(); ++ix) {
+        if (regular_grid.nx(ix) != grid.nx()) {
+          std::cout << regular_grid.nx(ix) << " != " << grid.nx() << std::endl;
+        }
+        EXPECT(regular_grid.nx(ix) == grid.nx());
+      }
       std::cout << " last index? " << regular_grid.index(grid.nx()-1, grid.ny()-1) << std::endl;
 
       orca::meshgenerator::SurroundingRectangle rectangle(distribution, cfg);


### PR DESCRIPTION
These are changes that aim to implement halos in the atlas-orca mesh generation. The code passes the atlas-orca and orca-jedi tests and superficially seems to do what it needs to do, but unfortunately it is still not fixing our problem with the interpolation of points at the divides between the checkboards.

Here are the issues I've come across:

1. When running in serial with a halo >= 1, there are failures in orca-jedi due to assert statements which look like they assume that the number of nodes can't be larger than the grid. It is possible to avoid this by preventing wrapping at the edge of the grid as shown in https://github.com/twsearle/atlas-orca/pull/4/commits/2d54e780d7696f542f395cf77ffd163aeb255365 but it needs an orca-jedi update to fix it properly.
2. Minor issue: there is code that attempts to prevent running in serial with a halo (https://github.com/s-good/atlas-orca/blob/feature/mpi-halo-resize/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc#L566) (although it actually seems to allow a halo of 1). I think that it is possible that we will want to use serial and a halo as e.g. an observation with a large footprint may require using grid points that wrap from one edge of the grid to another in the observation operator. However, this part of the code does not seem to be being used so isn't a priority to fix. 
3. When using checkerboard with a halo, this assert fails: https://github.com/s-good/atlas-orca/blob/feature/mpi-halo-resize/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc#L497. I suspect this is because of the wrapping at the northern boundary. A point within the halo to one side of the pivot point will wrap to a point on the other side of the pivot point, so the same grid cell appears twice. If this is true, then the issue can be avoided by only doing the assert if halo == 0. However, I've not tested that this is the cause so haven't committed that change.
4. Running checkerboard with a halo unfortunately makes no difference to the background interpolation values! I just get the same hofx numbers out no matter what halo I set. There must be something preventing the halo points being used. I'm suspicious of these lines: https://github.com/s-good/atlas-orca/blob/feature/mpi-halo-resize/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc#L448 and https://github.com/s-good/atlas-orca/blob/feature/mpi-halo-resize/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc#L449 as it looks like it says that there are no ghost points. It might also be connected to this code https://github.com/s-good/atlas-orca/blob/feature/mpi-halo-resize/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc#L137 which only counts up nodes that are not ghost points. However, I've tried various ways of editing these lines to count all points etc. and I end up with a floating point error which looks like some code is trying to access cells that are not defined. Is it possible that the halo exchange is not being done?