### PR TITLE
Updated logic

### DIFF
--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
@@ -84,9 +84,9 @@ LocalOrcaGrid::LocalOrcaGrid(const OrcaGrid& grid, const SurroundingRectangle& r
         idx_t ix_reg = ij_glb_haloed.i;
         idx_t iy_reg = ij_glb_haloed.j;
         idx_t reg_ii = -1;
-        // Are we in the ORCA halo? If so we use those points instead of wrapping to the
-        // other side of the grid.
-        if ( this->orca_halo( ix, iy ) ) {
+        // Are we in the ORCA edge points? If so we use those points instead of wrapping
+        // to the other side of the grid.
+        if ( this->orca_edge( ix, iy ) ) {
           // Find the information for the closest node to the ORCA halo point
           // that is inside the grid.
           idx_t ix_reg_h = ix_reg;
@@ -422,7 +422,7 @@ bool LocalOrcaGrid::water( idx_t ix, idx_t iy ) const {
 
   return orca_.water( ij_glb.i, ij_glb.j );
 }
-bool LocalOrcaGrid::orca_halo( idx_t ix, idx_t iy ) const {
+bool LocalOrcaGrid::orca_edge( idx_t ix, idx_t iy ) const {
   const auto ij_glb = this->orca_haloed_global_grid_ij( ix, iy );
   if ( ((ij_glb.i < 0) && (ij_glb.i >= -orca_.haloWest())) ||
        ((ij_glb.i >= orca_.nx()) && (ij_glb.i < (orca_.nx() + orca_.haloEast()))) ||

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
@@ -116,6 +116,11 @@ LocalOrcaGrid::LocalOrcaGrid(const OrcaGrid& grid, const SurroundingRectangle& r
         parts.at( ii ) = rectangle.parts.at( reg_ii );
         halo.at( ii ) = rectangle.halo.at( reg_ii );
         is_ghost.at( ii ) = rectangle.is_ghost.at( reg_ii );
+        // If this is a periodic point, then it is always a ghost point.
+        const auto ij_wrapped = this->orca_haloed_global_grid_ij( ix, iy );
+        if ( (ij_wrapped.i != ij_glb_haloed.i) || (ij_wrapped.j != ij_glb_haloed.j) ) {
+          is_ghost.at(ii) = 1;
+        }
       }
     }
   }

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
@@ -181,11 +181,11 @@ LocalOrcaGrid::LocalOrcaGrid(const OrcaGrid& grid, const SurroundingRectangle& r
              (ij_glb_haloed.i < 0)  ||
              (ij_glb_haloed.i >= orca_.nx()) ) {
 
-        // this one should wrap when we have a standard halo, but still
-        // preserve the orca halo as though points in the orca are real points
-        // for the purposes of the wrapping. But it isn't working quite right
-        // The southern boundary does not contain halo points apart from at the
-        // east and west limits.
+          // this one should wrap when we have a standard halo, but still
+          // preserve the orca halo as though points in the orca are real points
+          // for the purposes of the wrapping. But it isn't working quite right
+          // The southern boundary does not contain halo points apart from at the
+          // east and west limits.
           if ( (ij_glb_haloed.i > orca_.nx() + orca_.haloWest()) ||
                (ij_glb_haloed.j > orca_.ny() + orca_.haloNorth()) ||
                (ij_glb_haloed.i < - orca_.haloEast()) ||
@@ -418,7 +418,7 @@ bool LocalOrcaGrid::water( idx_t ix, idx_t iy ) const {
   return orca_.water( ij_glb.i, ij_glb.j );
 }
 bool LocalOrcaGrid::orca_halo( idx_t ix, idx_t iy ) const {
-  const auto ij_glb = this->global_ij( ix, iy );
+  const auto ij_glb = this->orca_haloed_global_grid_ij( ix, iy );
   if ( ((ij_glb.i < 0) && (ij_glb.i >= -orca_.haloWest())) ||
        ((ij_glb.i >= orca_.nx()) && (ij_glb.i < (orca_.nx() + orca_.haloEast()))) ||
        ((ij_glb.j < 0) && (ij_glb.j >= -orca_.haloSouth())) ||

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
@@ -174,12 +174,11 @@ LocalOrcaGrid::LocalOrcaGrid(const OrcaGrid& grid, const SurroundingRectangle& r
       if ( is_node.at( ii ) ) {
         is_ghost_including_orca_halo.at( ii ) = static_cast<bool>(is_ghost.at( ii ));
         const auto ij_glb_haloed = this->orca_haloed_global_grid_ij( ix, iy );
-        // The southern boundary does not contain halo points apart from at the
-        // east and west limits.
-        if ( this->orca_halo( ix, iy ) &&
-             ((ij_glb_haloed.j >= 0) ||
-              (ij_glb_haloed.i < 0) ||
-              (ij_glb_haloed.i >= orca_.nx())) ) {
+
+        if ( (ij_glb_haloed.j >= 0) ||
+             (ij_glb_haloed.i < 0)  ||
+             (ij_glb_haloed.i >= orca_.nx()) ) {
+
         // this one should wrap when we have a standard halo, but still
         // preserve the orca halo as though points in the orca are real points
         // for the purposes of the wrapping. But it isn't working quite right
@@ -358,18 +357,18 @@ void LocalOrcaGrid::flags( idx_t ix, idx_t iy, util::detail::BitflagsView<int>& 
       ASSERT(false);
   }
 
-  if ( this->is_ghost[this->index(ix, iy)] ) {
+  if ( this->is_ghost_including_orca_halo[this->index(ix, iy)] ) {
     flag_view.set( util::Topology::GHOST );
     if( this->orca_haloed_global_grid_index( ix, iy ) !=
         this->master_global_index( ix, iy ) ) {
       const auto normalised_xy = this->normalised_grid_xy( ix, iy );
-      if ( ij_glb.i >= orca_.nx() - orca_.haloWest() ) {
+      if ( ij_glb.i >= orca_.nx() ) {
         flag_view.set( util::Topology::PERIODIC );
       }
-      else if ( ij_glb.i < orca_.haloEast() - 1 ) {
+      else if ( ij_glb.i < 0 ) {
         flag_view.set( util::Topology::PERIODIC );
       }
-      if ( ij_glb.j >= orca_.ny() - orca_.haloNorth() - 1 ) {
+      if ( ij_glb.j >= orca_.ny() ) {
           flag_view.set( util::Topology::PERIODIC );
           if ( normalised_xy.x() > lon00_ + 90. ) {
               flag_view.set( util::Topology::EAST );
@@ -417,7 +416,7 @@ bool LocalOrcaGrid::water( idx_t ix, idx_t iy ) const {
   return orca_.water( ij_glb.i, ij_glb.j );
 }
 bool LocalOrcaGrid::orca_halo( idx_t ix, idx_t iy ) const {
-  const auto ij_glb = this->orca_haloed_global_grid_ij( ix, iy );
+  const auto ij_glb = this->global_ij( ix, iy );
   if ( ((ij_glb.i < 0) && (ij_glb.i >= -orca_.haloWest())) ||
        ((ij_glb.i >= orca_.nx()) && (ij_glb.i < (orca_.nx() + orca_.haloEast()))) ||
        ((ij_glb.j < 0) && (ij_glb.j >= -orca_.haloSouth())) ||

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
@@ -175,6 +175,8 @@ LocalOrcaGrid::LocalOrcaGrid(const OrcaGrid& grid, const SurroundingRectangle& r
         is_ghost_including_orca_halo.at( ii ) = static_cast<bool>(is_ghost.at( ii ));
         const auto ij_glb_haloed = this->orca_haloed_global_grid_ij( ix, iy );
 
+        // the southern boundary of the grid does not contain ghost points except at
+        // the east-west boundary.
         if ( (ij_glb_haloed.j >= 0) ||
              (ij_glb_haloed.i < 0)  ||
              (ij_glb_haloed.i >= orca_.nx()) ) {

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.h
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.h
@@ -72,7 +72,7 @@ class LocalOrcaGrid {
     idx_t orca_haloed_global_grid_index( idx_t ix, idx_t iy ) const;
     void flags( idx_t ix, idx_t iy, util::detail::BitflagsView<int>& flag_view ) const;
     bool water( idx_t ix, idx_t iy ) const;
-    bool orca_halo( idx_t ix, idx_t iy ) const;
+    bool orca_edge( idx_t ix, idx_t iy ) const;
 
  private:
     const OrcaGrid orca_;

--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
@@ -489,8 +489,7 @@ void OrcaMeshGenerator::build_remote_index(Mesh& mesh) const {
     Unique2Node global2local;
     for ( idx_t jnode = 0; jnode < nodes.size(); ++jnode ) {
         gidx_t uid = master_glb_idx( jnode );
-        if ( ( part( jnode ) != mypart ) ||
-             ( ( master_glb_idx( jnode ) != glb_idx( jnode ) ) && ( part( jnode ) == mypart ) ) ) {
+        if ( ghost( jnode ) ) {
             send_uid[part( jnode )].push_back( uid );
             req_lidx[part( jnode )].push_back( jnode );
             ridx( jnode ) = -1;

--- a/src/tests/test_orca_local_grid.cc
+++ b/src/tests/test_orca_local_grid.cc
@@ -140,7 +140,7 @@ CASE("test surrounding local_orca ") {
           local_orca.flags( i, j, flags_view );
 
           // check points in the orca halo behave as expected.
-          if (local_orca.orca_halo( i, j ) &&
+          if (local_orca.orca_edge( i, j ) &&
               ((ix_glb >= grid.nx()) || (ix_glb > grid.nx()/2 && iy_glb > grid.ny()))) {
             // this grid point should be a ghost point.
             if ( ohgg_ij.j >= 0 or ohgg_ij.i < 0 or ohgg_ij.i >= grid.nx() ) {

--- a/src/tests/test_orca_mesh_boundaries.cc
+++ b/src/tests/test_orca_mesh_boundaries.cc
@@ -60,8 +60,9 @@ CASE( "test haloExchange " ) {
 
     for ( auto distributionName : distributionNames ) {
         for ( auto gridname : gridnames ) {
-            for ( int64_t halo = 0; halo < 1; ++halo ) {
-                if ( distributionName == "serial" && halo != 0 )
+            for ( int64_t halo = 0; halo < 2; ++halo ) {
+                if ( (distributionName == "serial" && halo != 0) ||
+                     (mpi::size() == 1) )
                   continue;
                 SECTION( gridname + "_" + distributionName + "_halo" + std::to_string(halo) ) {
                     auto grid = Grid(gridname);

--- a/src/tests/test_orca_mesh_boundaries.cc
+++ b/src/tests/test_orca_mesh_boundaries.cc
@@ -61,8 +61,7 @@ CASE( "test haloExchange " ) {
     for ( auto distributionName : distributionNames ) {
         for ( auto gridname : gridnames ) {
             for ( int64_t halo = 0; halo < 2; ++halo ) {
-                if ( (distributionName == "serial" && halo != 0) ||
-                     (mpi::size() == 1) )
+                if ( ((distributionName == "serial") || (mpi::size() == 1)) && (halo != 0) )
                   continue;
                 SECTION( gridname + "_" + distributionName + "_halo" + std::to_string(halo) ) {
                     auto grid = Grid(gridname);


### PR DESCRIPTION
Orca-jedi tests are currently failing. This PR contains some small changes that I think improves the logic in a few places although they don't correct the problem. The main issue is the code around lines 178-180 in the changes below. This compares to this code in the develop branch: https://github.com/twsearle/atlas-orca/blob/develop/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc#L411.

The develop branch code uses the information from the orca halo if j > 0 or i < 0 to define if there are ghost points. This means that there are two points at the right of the grid in the bottom two rows that do not use the orca halo information that I would expect to be halo points and hence ghost points. My version of the code applies the orca halo information to those points. 

The difference in the ghost point information affects the field norm calculation causing orca-jedi tests to fail. Unfortunately I can't work out why the original code is the way it is. Changing the logic to match the original code causes other tests to fail in a way that doesn't look easy to fix. I'm reluctant to put effort into this without understanding the logic behind it!

Apart from the differences in the field norms, all tests pass.